### PR TITLE
Feat/local coversfeat: local covers for blog + cleanup

### DIFF
--- a/.env.db
+++ b/.env.db
@@ -1,6 +1,0 @@
-SUPABASE_DB_URL=postgresql://postgres.twwgfrbcndouazujgcma:L4F1uN9IQ2ssmGEd@aws-1-eu-west-2.pooler.supabase.com:5432/postgres?sslmode=require
-
-
-
-
-

--- a/Tools/check_article.py
+++ b/Tools/check_article.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""
+Controllo presenza articolo per slug+locale via REST Supabase.
+Esegui:
+  .\.venv\Scripts\python.exe Tools\check_article.py "cosa-significa-conoscenza-consapevolmente-etica" it
+"""
+import sys
+import re
+from pathlib import Path
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_FILE = ROOT / ".env.local"
+
+def load_env() -> dict:
+    env = {}
+    for line in ENV_FILE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z0-9_]+)=(.*)$", line)
+        if m:
+            k, v = m.group(1), m.group(2)
+            if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+                v = v[1:-1]
+            env[k] = v
+    return env
+
+def main():
+    if len(sys.argv) < 3:
+        print("Uso: check_article.py <slug> <locale>")
+        sys.exit(2)
+    slug, locale = sys.argv[1], sys.argv[2]
+    env = load_env()
+    url = env["NEXT_PUBLIC_SUPABASE_URL"].rstrip("/") + "/rest/v1/articles"
+    anon = env["NEXT_PUBLIC_SUPABASE_ANON_KEY"]
+    headers = {"apikey": anon, "Authorization": f"Bearer {anon}", "Accept": "application/json"}
+    params = {
+        "select": "slug,locale,title,category,published,published_at",
+        "slug": f"eq.{slug}",
+        "locale": f"eq.{locale}",
+        "published": "eq.true",
+        "limit": "2",
+    }
+    r = requests.get(url, headers=headers, params=params, timeout=15)
+    print("[STATUS]", r.status_code)
+    print("[JSON]", r.json())
+    if r.status_code == 200 and r.json():
+        print("[OK] Articolo trovato.")
+    else:
+        print("[MISS] Nessun articolo con quello slug/locale pubblicato.")
+
+if __name__ == "__main__":
+    main()

--- a/Tools/db_insert_article.py
+++ b/Tools/db_insert_article.py
@@ -1,0 +1,68 @@
+# Tools/db_insert_article.py
+import os, argparse, re
+from pathlib import Path
+from dotenv import load_dotenv
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+load_dotenv(".env.db")
+DB_URL = os.getenv("SUPABASE_DB_URL")
+if not DB_URL:
+    raise RuntimeError("SUPABASE_DB_URL non trovato in .env.db")
+
+def slugify(s: str) -> str:
+    s = s.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s, flags=re.UNICODE)
+    s = re.sub(r"[\s_-]+", "-", s)
+    return s.strip("-")
+
+def read_body(body: str) -> str:
+    # Se passi @file.md legge da file, altrimenti usa il testo così com'è
+    if body.startswith("@"):
+        p = Path(body[1:])
+        return p.read_text(encoding="utf-8")
+    return body
+
+def upsert_article(slug, title, summary, body_md, cover_url, locale, publish):
+    sql = """
+    INSERT INTO public.articles (slug, title, summary_it, body_md, cover_url, locale, published_at)
+    VALUES (%s, %s, %s, %s, %s, %s, CASE WHEN %s THEN NOW() ELSE NULL END)
+    ON CONFLICT (slug) DO UPDATE
+    SET title = EXCLUDED.title,
+        summary_it = EXCLUDED.summary_it,
+        body_md = EXCLUDED.body_md,
+        cover_url = EXCLUDED.cover_url,
+        locale = EXCLUDED.locale,
+        published_at = CASE WHEN %s THEN NOW() ELSE public.articles.published_at END
+    RETURNING id, slug, locale, published_at;
+    """
+    with psycopg2.connect(DB_URL) as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, (slug, title, summary, body_md, cover_url, locale, publish, publish))
+        row = cur.fetchone()
+        return row
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="Upsert articolo su Supabase/Postgres")
+    ap.add_argument("--title", required=True)
+    ap.add_argument("--slug", default="")
+    ap.add_argument("--summary", default="")
+    ap.add_argument("--body", required=True, help="Testo o @file.md")
+    ap.add_argument("--cover", default="")
+    ap.add_argument("--locale", default="it", choices=["it","en"])
+    ap.add_argument("--publish", action="store_true")
+    args = ap.parse_args()
+
+    slug = args.slug or slugify(args.title)
+    body_md = read_body(args.body)
+
+    row = upsert_article(
+        slug=slug,
+        title=args.title,
+        summary=args.summary,
+        body_md=body_md,
+        cover_url=args.cover,
+        locale=args.locale,
+        publish=args.publish,
+    )
+    url = f"/{row['locale']}/news/{row['slug']}"
+    print(f"[OK] id={row['id']} | slug={row['slug']} | locale={row['locale']} | url={url} | published_at={row['published_at']}")

--- a/Tools/db_maintain.py
+++ b/Tools/db_maintain.py
@@ -1,0 +1,176 @@
+# Tools/db_maintain.py
+# Utility DB (Postgres Supabase) per inserire/aggiornare articoli dal PC.
+
+import os
+import sys
+import argparse
+import datetime as dt
+from pathlib import Path
+import psycopg2
+import psycopg2.extras
+from dotenv import load_dotenv
+load_dotenv(".env.db")
+
+DB_URL = os.getenv("SUPABASE_DB_URL") or os.getenv("DATABASE_URL")
+if not DB_URL:
+    print("[ERR] Variabile SUPABASE_DB_URL (o DATABASE_URL) non trovata. Mettila in .env.db e fai `dotenv` se usi direnv, oppure esportala.")
+    sys.exit(2)
+
+def conn():
+    return psycopg2.connect(DB_URL)
+
+def ensure_schema():
+    """Garantisce vincoli minimi: UNIQUE(slug, locale) e colonna category."""
+    sql = """
+    DO $$
+    BEGIN
+        -- colonna category se manca
+        IF NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'articles' AND column_name = 'category'
+        ) THEN
+            ALTER TABLE public.articles ADD COLUMN category text DEFAULT 'blog';
+        END IF;
+
+        -- indice/vincolo unico su (slug, locale)
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = 'public' AND indexname = 'ux_articles_slug_locale'
+        ) THEN
+            CREATE UNIQUE INDEX ux_articles_slug_locale ON public.articles (slug, locale);
+        END IF;
+    END$$;
+    """
+    with conn() as cx, cx.cursor() as cur:
+        cur.execute(sql)
+    print("[OK] Schema controllato/aggiornato.")
+
+def read_body(body_text: str | None, body_file: str | None) -> str:
+    if body_file:
+        p = Path(body_file)
+        if not p.exists():
+            raise FileNotFoundError(f"Body file non trovato: {p}")
+        return p.read_text(encoding="utf-8")
+    return body_text or ""
+
+def upsert_article(
+    slug: str,
+    locale: str,
+    title: str,
+    summary: str,
+    body_text: str | None,
+    body_file: str | None,
+    category: str = "blog",
+    cover_url: str | None = None,
+    published_at: str | None = None,
+):
+    body_md = read_body(body_text, body_file)
+    # published_at: ISO, es. "2025-09-20T10:30:00" oppure solo data
+    pub = None
+    if published_at:
+        pub = dt.datetime.fromisoformat(published_at)
+
+    sql = """
+    INSERT INTO public.articles (slug, locale, title, summary, body_md, cover_url, category, published_at)
+    VALUES (%(slug)s, %(locale)s, %(title)s, %(summary)s, %(body_md)s, %(cover_url)s, %(category)s, COALESCE(%(published_at)s, NOW()))
+    ON CONFLICT (slug, locale) DO UPDATE SET
+        title        = EXCLUDED.title,
+        summary      = EXCLUDED.summary,
+        body_md      = EXCLUDED.body_md,
+        cover_url    = EXCLUDED.cover_url,
+        category     = EXCLUDED.category,
+        published_at = COALESCE(EXCLUDED.published_at, public.articles.published_at);
+    """
+    data = dict(
+        slug=slug,
+        locale=locale,
+        title=title,
+        summary=summary,
+        body_md=body_md,
+        cover_url=cover_url,
+        category=category,
+        published_at=pub,
+    )
+    with conn() as cx, cx.cursor() as cur:
+        cur.execute(sql, data)
+    print(f"[OK] Upsert articolo: {locale}/{slug} (cat: {category})")
+
+def delete_by_slug(slug: str, locale: str | None):
+    if locale:
+        sql = "DELETE FROM public.articles WHERE slug=%s AND locale=%s"
+        params = (slug, locale)
+    else:
+        sql = "DELETE FROM public.articles WHERE slug=%s"
+        params = (slug,)
+
+    with conn() as cx, cx.cursor() as cur:
+        cur.execute(sql, params)
+        print(f"[OK] Eliminati {cur.rowcount} record per slug='{slug}'{(' locale='+locale) if locale else ''}")
+
+def list_articles(category: str | None = None):
+    sql = "SELECT id, slug, locale, title, category, published_at FROM public.articles"
+    if category:
+        sql += " WHERE category=%s ORDER BY published_at DESC NULLS LAST"
+        params = (category,)
+    else:
+        sql += " ORDER BY published_at DESC NULLS LAST"
+        params = ()
+    with conn() as cx, cx.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+        cur.execute(sql, params)
+        for r in cur.fetchall():
+            print(tuple(r))
+
+def main():
+    ap = argparse.ArgumentParser(description="DB maintain (articles)")
+    ap.add_argument("--ensure-schema", action="store_true", help="crea vincoli e colonna category se mancanti")
+    ap.add_argument("--list", nargs="?", const="*", help="lista articoli (opzionalmente filtra per category)")
+    ap.add_argument("--delete-by-slug", nargs="+", help="slug [locale] : elimina un articolo (o tutte le lingue)")
+    ap.add_argument("--upsert-article", action="store_true", help="inserisce/aggiorna un articolo")
+
+    # campi upsert
+    ap.add_argument("--slug")
+    ap.add_argument("--locale")
+    ap.add_argument("--title")
+    ap.add_argument("--summary", default="")
+    ap.add_argument("--body", help="body inline (markdown)")
+    ap.add_argument("--body-file", help="path file markdown (UTF-8)")
+    ap.add_argument("--category", default="blog")
+    ap.add_argument("--cover-url")
+    ap.add_argument("--published-at", help="ISO datetime es. 2025-09-20T10:30:00")
+
+    args = ap.parse_args()
+
+    if args.ensure_schema:
+        ensure_schema()
+
+    if args.list is not None:
+        cat = None if args.list in (None, "*") else args.list
+        list_articles(cat)
+
+    if args.delete_by_slug:
+        slug = args.delete_by_slug[0]
+        locale = args.delete_by_slug[1] if len(args.delete_by_slug) > 1 else None
+        delete_by_slug(slug, locale)
+
+    if args.upsert_article:
+        required = ("slug", "locale", "title")
+        missing = [k for k in required if getattr(args, k) in (None, "")]
+        if missing:
+            print(f"[ERR] mancano parametri: {', '.join(missing)}")
+            return 2
+        upsert_article(
+            slug=args.slug,
+            locale=args.locale,
+            title=args.title,
+            summary=args.summary or "",
+            body_text=args.body,
+            body_file=args.body_file,
+            category=args.category,
+            cover_url=args.cover_url,
+            published_at=args.published_at,
+        )
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/Tools/db_query.py
+++ b/Tools/db_query.py
@@ -1,0 +1,31 @@
+# Tools/db_query.py
+# Esegue query SQL su Supabase/Postgres leggendo .env.db
+
+import psycopg2
+import os
+from dotenv import load_dotenv
+
+# Carica variabili da .env.db
+load_dotenv(dotenv_path=".env.db")
+
+DB_URL = os.getenv("SUPABASE_DB_URL")
+if not DB_URL:
+    raise RuntimeError("SUPABASE_DB_URL non trovato in .env.db")
+
+def run_query(query: str):
+    conn = psycopg2.connect(DB_URL)
+    cur = conn.cursor()
+    cur.execute(query)
+    try:
+        rows = cur.fetchall()
+        for row in rows:
+            print(row)
+    except psycopg2.ProgrammingError:
+        conn.commit()
+        print("[OK] Query eseguita (nessun risultato da mostrare)")
+    cur.close()
+    conn.close()
+
+if __name__ == "__main__":
+    # Esempio: lista ultimi articoli
+    run_query("SELECT id, slug, title FROM articles ORDER BY created_at DESC LIMIT 5;")

--- a/Tools/db_test.py
+++ b/Tools/db_test.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+Diagnostica connessione Postgres diretta (opzionale).
+Legge SUPABASE_DB_URL da .env.local se presente, altrimenti esce.
+Non usato in produzione web: solo test/batch locali.
+"""
+import os, re, sys
+from pathlib import Path
+import psycopg2
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_FILE = ROOT / ".env.local"
+
+def get_env(k: str, d: str = "") -> str:
+    val = os.environ.get(k, d)
+    if val:
+        return val
+    if ENV_FILE.exists():
+        for line in ENV_FILE.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"): 
+                continue
+            m = re.match(r'^([A-Za-z0-9_]+)=(.*)$', line)
+            if m and m.group(1) == k:
+                v = m.group(2).strip()
+                if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+                    v = v[1:-1]
+                return v
+    return d
+
+def main():
+    dsn = get_env("SUPABASE_DB_URL", "")
+    if not dsn:
+        print("ℹ️  SUPABASE_DB_URL non definita. Salto test DB diretto.")
+        sys.exit(0)
+
+    print("[INFO] Connessione Postgres…")
+    try:
+        with psycopg2.connect(dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute("select version();")
+                print("[OK] Versione:", cur.fetchone()[0])
+                cur.execute("select count(*) from public.articles;")
+                print("[OK] Totale articoli:", cur.fetchone()[0])
+        print("[DONE] db_test.py completato.")
+    except Exception as e:
+        print("❌ Errore Postgres:", repr(e))
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/Tools/list_articles.py
+++ b/Tools/list_articles.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""
+Elenca articoli pubblicati: slug, locale, title.
+Esegui:
+  .\.venv\Scripts\python.exe Tools\list_articles.py
+"""
+import re
+from pathlib import Path
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_FILE = ROOT / ".env.local"
+
+def load_env() -> dict:
+    env = {}
+    for line in ENV_FILE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z0-9_]+)=(.*)$", line)
+        if m:
+            k, v = m.group(1), m.group(2)
+            if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+                v = v[1:-1]
+            env[k] = v
+    return env
+
+def main():
+    env = load_env()
+    url = env["NEXT_PUBLIC_SUPABASE_URL"].rstrip("/") + "/rest/v1/articles"
+    anon = env["NEXT_PUBLIC_SUPABASE_ANON_KEY"]
+    headers = {"apikey": anon, "Authorization": f"Bearer {anon}", "Accept": "application/json"}
+    params = {
+        "select": "slug,locale,title,category,published_at",
+        "published": "eq.true",
+        "order": "published_at.desc",
+        "limit": "100",
+    }
+    r = requests.get(url, headers=headers, params=params, timeout=15)
+    r.raise_for_status()
+    rows = r.json()
+    print(f"[COUNT] {len(rows)}")
+    for i, x in enumerate(rows, 1):
+        print(f"{i:>2}) {x.get('locale')} | {x.get('slug')} | {x.get('title')} | {x.get('category')}")
+
+if __name__ == "__main__":
+    main()

--- a/Tools/seed_articles.py
+++ b/Tools/seed_articles.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""
+Seed iniziale articoli (IT/EN) con SERVICE ROLE (bypassa RLS).
+Esegui: .\.venv\Scripts\python.exe Tools\seed_articles.py
+"""
+import re
+import sys
+import json
+from pathlib import Path
+import requests
+from datetime import datetime, timezone
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_FILE = ROOT / ".env.local"
+
+def load_env() -> dict:
+    if not ENV_FILE.exists():
+        raise RuntimeError(f".env.local mancante: {ENV_FILE}")
+    env = {}
+    for line in ENV_FILE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z0-9_]+)=(.*)$", line)
+        if m:
+            k, v = m.group(1), m.group(2)
+            if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+                v = v[1:-1]
+            env[k] = v
+    return env
+
+SEED = [
+    {
+        "slug": "what-ethically-conscious-knowledge-means",
+        "title": "What Ethically Conscious Knowledge Means",
+        "summary": "A short evergreen explaining the idea behind ethically conscious learning.",
+        "body_md": "# Ethically Conscious Knowledge\n\nWe align skills with responsibility and inclusion...",
+        "cover_url": "https://images.unsplash.com/photo-1521791136064-7986c2920216",
+        "locale": "en",
+        "category": "evergreen",
+        "published": True,
+    },
+    {
+        "slug": "cosa-significa-conoscenza-consapevolmente-etica",
+        "title": "Cosa significa conoscenza consapevolmente etica",
+        "summary": "Un evergreen che chiarisce il nostro approccio formativo.",
+        "body_md": "# Conoscenza consapevolmente etica\n\nUniamo competenza tecnica, responsabilità e inclusione...",
+        "cover_url": "https://images.unsplash.com/photo-1496307042754-b4aa456c4a2d",
+        "locale": "it",
+        "category": "evergreen",
+        "published": True,
+    },
+    {
+        "slug": "perche-i-metodi-di-borsa-pubblici-non-reggono",
+        "title": "Perché i metodi di borsa pubblici non reggono",
+        "summary": "Anche se funzionano inizialmente, l'esposizione ne erode l'efficacia.",
+        "body_md": "## Perché\nLa dinamica di mercato e l'arbitraggio riducono i vantaggi...",
+        "cover_url": "https://images.unsplash.com/photo-1526304640581-d334cdbbf45e",
+        "locale": "it",
+        "category": "markets",
+        "published": True,
+    },
+]
+
+def now_utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+def main():
+    env = load_env()
+    url = env.get("NEXT_PUBLIC_SUPABASE_URL")
+    srv = env.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not srv:
+        raise RuntimeError("NEXT_PUBLIC_SUPABASE_URL o SUPABASE_SERVICE_ROLE_KEY mancanti in .env.local")
+
+    rest = url.rstrip("/") + "/rest/v1/articles"
+    headers = {
+        "apikey": srv,
+        "Authorization": f"Bearer {srv}",
+        "Content-Type": "application/json",
+        "Prefer": "resolution=merge-duplicates,return=representation",
+    }
+
+    for row in SEED:
+        payload = dict(row)
+        if payload.get("published") and not payload.get("published_at"):
+            payload["published_at"] = now_utc_iso()
+        params = {"slug": f"eq.{payload['slug']}"}
+        r = requests.patch(rest, headers=headers, params=params, data=json.dumps(payload), timeout=20)
+        if r.status_code not in (200, 204):
+            r = requests.post(rest, headers=headers, data=json.dumps(payload), timeout=20)
+        if r.status_code not in (200, 201):
+            print(f"❌ Seed fallito per {payload['slug']}: {r.status_code} {r.text}")
+            sys.exit(1)
+        print(f"[OK] Upsert: {payload['slug']}")
+    print("[DONE] seed_articles.py completato.")
+
+if __name__ == "__main__":
+    main()

--- a/Tools/setup_local_covers.py
+++ b/Tools/setup_local_covers.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+r"""
+Setup immagini locali per gli articoli e normalizzazione cover_url.
+
+Funzioni:
+- Crea webapp/public/covers/ e un placeholder.svg se non presenti
+- Copia immagini da una cartella sorgente dentro public/covers/ rinominando per slug
+- Normalizza cover_url nel DB: preferisce file locali, fallback a /covers/placeholder.svg
+- Report finale
+
+Uso (PowerShell):
+  .\.venv\Scripts\python.exe Tools\setup_local_covers.py --src "C:\path\alle\immagini"
+Opzioni:
+  --src "DIR"           Cartella sorgente immagini (facoltativa). I file devono chiamarsi come lo slug
+                        (es: guida-sicurezza-digitale.jpg). Se omessa, non copia nulla.
+  --ext-priority "jpg,png,jpeg"
+                        Ordine preferito delle estensioni quando si cercano file esistenti (default: jpg,png,jpeg).
+  --dry-run             Non scrive nulla su disco e non aggiorna il DB; mostra solo cosa farebbe.
+  --only-files          Esegue SOLO la parte filesystem (cartelle, placeholder, copia immagini).
+  --only-db             Esegue SOLO la normalizzazione nel DB (non tocca file).
+Prerequisiti:
+- .env.local in root con NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+import requests
+
+# -----------------------------------------------------------------------------
+# Costanti percorso
+# -----------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[1]
+WEBAPP_DIR = ROOT / "webapp"
+PUBLIC_DIR = WEBAPP_DIR / "public"
+COVERS_DIR = PUBLIC_DIR / "covers"
+ENV_FILE = ROOT / ".env.local"
+
+PLACEHOLDER_SVG = """<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800">
+  <defs>
+    <style>
+      .bg { fill: #f2f2f2; }
+      .rect { fill: #d9d9d9; }
+      .txt { font: 48px sans-serif; fill: #777; }
+    </style>
+  </defs>
+  <rect class="bg" width="100%" height="100%"/>
+  <rect class="rect" x="100" y="120" width="1000" height="560" rx="24"/>
+  <text class="txt" x="50%" y="50%" text-anchor="middle" dominant-baseline="middle">No cover</text>
+</svg>
+""".strip()
+
+# -----------------------------------------------------------------------------
+# Util
+# -----------------------------------------------------------------------------
+
+def load_env(path: Path) -> Dict[str, str]:
+    if not path.exists():
+        raise RuntimeError(f".env.local non trovato: {path}")
+    env: Dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z0-9_]+)=(.*)$", line)
+        if not m:
+            continue
+        k, v = m.group(1), m.group(2)
+        if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+            v = v[1:-1]
+        env[k] = v
+    return env
+
+
+def ensure_dirs(dry: bool = False) -> None:
+    for d in (WEBAPP_DIR, PUBLIC_DIR, COVERS_DIR):
+        if not d.exists():
+            if dry:
+                print(f"[DRY] mkdir {d}")
+            else:
+                d.mkdir(parents=True, exist_ok=True)
+                print(f"[OK] creato: {d}")
+
+
+def ensure_placeholder(dry: bool = False) -> None:
+    target = COVERS_DIR / "placeholder.svg"
+    if target.exists():
+        print("[SKIP] placeholder.svg già presente")
+        return
+    if dry:
+        print(f"[DRY] write {target}")
+    else:
+        target.write_text(PLACEHOLDER_SVG, encoding="utf-8")
+        print("[OK] creato placeholder.svg")
+
+
+def find_first_existing(base_dir: Path, slug: str, exts: List[str]) -> Optional[Path]:
+    for ext in exts:
+        p = base_dir / f"{slug}.{ext}"
+        if p.exists():
+            return p
+    return None
+
+
+@dataclass
+class CopyResult:
+    copied: List[Tuple[str, str]]  # (slug, filename)
+    missing: List[str]             # slug senza file sorgente
+    skipped: List[str]             # file già presenti
+
+
+def copy_images_from_src(
+    src_dir: Optional[Path],
+    slugs: Iterable[str],
+    ext_priority: List[str],
+    dry: bool = False
+) -> CopyResult:
+    copied: List[Tuple[str, str]] = []
+    missing: List[str] = []
+    skipped: List[str] = []
+
+    if not src_dir:
+        print("[INFO] --src non fornito: salto la copia immagini.")
+        return CopyResult(copied, missing, skipped)
+
+    if not src_dir.exists():
+        raise RuntimeError(f"Cartella sorgente non trovata: {src_dir}")
+
+    for slug in slugs:
+        src_path = find_first_existing(src_dir, slug, ext_priority)
+        if not src_path:
+            missing.append(slug)
+            continue
+
+        dst_path = COVERS_DIR / src_path.name  # mantiene estensione
+        if dst_path.exists():
+            skipped.append(slug)
+            continue
+
+        if dry:
+            print(f"[DRY] copy {src_path} -> {dst_path}")
+        else:
+            shutil.copy2(src_path, dst_path)
+            copied.append((slug, dst_path.name))
+
+    return CopyResult(copied, missing, skipped)
+
+# -----------------------------------------------------------------------------
+# Supabase
+# -----------------------------------------------------------------------------
+
+@dataclass
+class Article:
+    id: str
+    slug: str
+    cover_url: Optional[str]
+
+def fetch_articles(base_url: str, anon_key: str) -> List[Article]:
+    url = base_url.rstrip("/") + "/rest/v1/articles"
+    headers = {"apikey": anon_key, "Authorization": f"Bearer {anon_key}", "Accept": "application/json"}
+    params = {"select": "id,slug,cover_url", "limit": "1000", "order": "slug.asc"}
+    r = requests.get(url, headers=headers, params=params, timeout=25)
+    if r.status_code != 200:
+        raise RuntimeError(f"Errore fetch: {r.status_code} {r.text}")
+    rows = r.json()
+    return [Article(id=row["id"], slug=row["slug"], cover_url=row.get("cover_url")) for row in rows]
+
+
+def desired_cover_path_for_slug(slug: str, exts: List[str]) -> str:
+    # scegli l'estensione presente in /covers; altrimenti fallback jpg
+    for ext in exts:
+        if (COVERS_DIR / f"{slug}.{ext}").exists():
+            return f"/covers/{slug}.{ext}"
+    # nessun file -> placeholder
+    if (COVERS_DIR / "placeholder.svg").exists():
+        return "/covers/placeholder.svg"
+    # safety fallback (se qualcuno ha cancellato il placeholder tra un run e l'altro)
+    return "/covers/placeholder.svg"
+
+
+@dataclass
+class DbUpdateResult:
+    to_update: List[Tuple[str, str, str]]  # (slug, old, new)
+    updated: List[str]
+    unchanged: List[str]
+
+def compute_db_updates(articles: List[Article], ext_priority: List[str]) -> DbUpdateResult:
+    to_update: List[Tuple[str, str, str]] = []
+    unchanged: List[str] = []
+
+    for a in articles:
+        want = desired_cover_path_for_slug(a.slug, ext_priority)
+        cur = (a.cover_url or "").strip()
+        if cur != want:
+            to_update.append((a.slug, cur, want))
+        else:
+            unchanged.append(a.slug)
+
+    return DbUpdateResult(to_update=to_update, updated=[], unchanged=unchanged)
+
+
+def apply_db_updates(
+    base_url: str,
+    service_key: str,
+    changes: List[Tuple[str, str, str]],
+    dry: bool = False
+) -> List[str]:
+    """Ritorna la lista di slug aggiornati."""
+    if not changes:
+        return []
+
+    url = base_url.rstrip("/") + "/rest/v1/articles"
+    headers = {
+        "apikey": service_key,
+        "Authorization": f"Bearer {service_key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+    }
+
+    updated: List[str] = []
+    for slug, old, new in changes:
+        if dry:
+            print(f"[DRY] PATCH slug={slug} cover_url: '{old}' -> '{new}'")
+            updated.append(slug)
+            continue
+
+        params = {"slug": f"eq.{slug}"}
+        payload = {"cover_url": new}
+        r = requests.patch(url, headers=headers, params=params, data=json.dumps(payload), timeout=25)
+        if r.status_code in (200, 204):
+            updated.append(slug)
+            print(f"[OK] {slug} -> {new}")
+        else:
+            print(f"[ERR] {slug}: {r.status_code} {r.text}")
+
+    return updated
+
+# -----------------------------------------------------------------------------
+# Main CLI
+# -----------------------------------------------------------------------------
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Setup immagini locali e normalizzazione cover_url.")
+    ap.add_argument("--src", type=str, default=None, help="Cartella sorgente con immagini nominate per slug.")
+    ap.add_argument("--ext-priority", type=str, default="jpg,png,jpeg", help="Ordine estensioni da considerare.")
+    ap.add_argument("--dry-run", action="store_true", help="Non scrive su disco / DB; mostra le azioni.")
+    ap.add_argument("--only-files", action="store_true", help="Esegue solo filesystem (cartelle, placeholder, copia).")
+    ap.add_argument("--only-db", action="store_true", help="Esegue solo normalizzazione DB (no file).")
+    args = ap.parse_args()
+
+    if args.only_files and args.only_db:
+        raise SystemExit("Impossibile usare --only-files e --only-db insieme.")
+
+    ext_priority = [e.strip().lstrip(".").lower() for e in args.ext_priority.split(",") if e.strip()]
+    src_dir = Path(args.src) if args.src else None
+
+    print("[INFO] Root:", ROOT)
+    print("[INFO] Covers dir:", COVERS_DIR)
+    print("[INFO] Ext priority:", ext_priority)
+    if src_dir:
+        print("[INFO] Source dir:", src_dir)
+
+    # 1) Filesystem
+    if not args.only_db:
+        ensure_dirs(dry=args.dry_run)
+        ensure_placeholder(dry=args.dry_run)
+
+    # 2) Supabase fetch (ci serve sempre per sapere gli slug, anche per la copia)
+    env = load_env(ENV_FILE)
+    base = env.get("NEXT_PUBLIC_SUPABASE_URL")
+    anon = env.get("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    srv  = env.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not base or not anon or not srv:
+        raise RuntimeError("Variabili mancanti in .env.local (URL/ANON/SERVICE_ROLE).")
+
+    articles = fetch_articles(base, anon)
+    slugs = [a.slug for a in articles]
+    print(f"[INFO] Articoli trovati: {len(slugs)}")
+
+    # 3) Copia immagini (se richiesto)
+    if not args.only_db:
+        res = copy_images_from_src(src_dir, slugs, ext_priority, dry=args.dry_run)
+        if src_dir:
+            print(f"[COPY] Copiati: {len(res.copied)} | Già presenti: {len(res.skipped)} | Mancanti in src: {len(res.missing)}")
+
+    # 4) Calcola e applica aggiornamenti DB
+    if not args.only_files:
+        plan = compute_db_updates(articles, ext_priority)
+        print(f"[PLAN] Da aggiornare cover_url: {len(plan.to_update)} | Invariate: {len(plan.unchanged)}")
+        updated = apply_db_updates(base, srv, plan.to_update, dry=args.dry_run)
+        print(f"[DONE] Aggiornati nel DB: {len(updated)}")
+
+    # 5) Suggerimenti finali
+    print("\n[HINT] Metti i file immagine reali in:", COVERS_DIR)
+    print("       Nomi richiesti: <slug>.<estensione> (default jpg/png/jpeg)")
+    print("       Fallback usato se assenti: /covers/placeholder.svg")
+
+if __name__ == "__main__":
+    main()

--- a/Tools/test_supabase_api.py
+++ b/Tools/test_supabase_api.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+Verifica API Supabase (REST) leggendo .env.local in root.
+- Usa anon key e RLS
+- Restituisce fino a 3 articoli pubblicati
+"""
+import re
+import sys
+from pathlib import Path
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_FILE = ROOT / ".env.local"
+
+def load_env_from_file(path: Path) -> dict:
+    if not path.exists():
+        raise RuntimeError(f"❌ .env.local non trovato: {path}")
+    env = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z0-9_]+)=(.*)$", line)
+        if m:
+            k, v = m.group(1), m.group(2)
+            if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+                v = v[1:-1]
+            env[k] = v
+    return env
+
+def main():
+    env = load_env_from_file(ENV_FILE)
+    url = env.get("NEXT_PUBLIC_SUPABASE_URL")
+    anon = env.get("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    if not url or not anon:
+        raise RuntimeError("❌ Variabili mancanti: NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY")
+
+    rest = url.rstrip("/") + "/rest/v1/articles"
+    headers = {
+        "apikey": anon,
+        "Authorization": f"Bearer {anon}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Prefer": "count=exact",
+    }
+    params = {
+        "select": "id,slug,title,locale,category,published_at",
+        "published": "eq.true",
+        "order": "published_at.desc",
+        "limit": "3",
+    }
+
+    print(f"[INFO] REST endpoint: {rest}")
+    r = requests.get(rest, headers=headers, params=params, timeout=15)
+    if r.status_code != 200:
+        print("❌ Errore REST:", r.status_code, r.text)
+        sys.exit(1)
+
+    rows = r.json()
+    print(f"[OK] Righe lette: {len(rows)}")
+    for i, row in enumerate(rows, 1):
+        print(f" {i}) {row.get('slug')} | {row.get('title')} | {row.get('locale')} | {row.get('category')} | {row.get('published_at')}")
+    print("[DONE] test_supabase_api.py completato.")
+
+if __name__ == "__main__":
+    main()

--- a/Tools/update_category.py
+++ b/Tools/update_category.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+r"""
+Aggiorna il campo `category` per uno o più slug usando la SERVICE ROLE KEY (bypass RLS).
+
+Uso (PowerShell):
+  .\.venv\Scripts\python.exe Tools\update_category.py evergreen <slug1> [slug2] ...
+
+Esempio:
+  .\.venv\Scripts\python.exe Tools\update_category.py evergreen conoscenza-consapevolmente-etica guida-sicurezza-digitale
+"""
+import sys
+import re
+import json
+from pathlib import Path
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_FILE = ROOT / ".env.local"
+
+def load_env() -> dict:
+    env: dict[str, str] = {}
+    if not ENV_FILE.exists():
+        raise RuntimeError(f".env.local mancante: {ENV_FILE}")
+    for line in ENV_FILE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z0-9_]+)=(.*)$", line)
+        if m:
+            k, v = m.group(1), m.group(2)
+            if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+                v = v[1:-1]
+            env[k] = v
+    return env
+
+def patch_category(base_url: str, srv_key: str, slug: str, category: str) -> bool:
+    url = base_url.rstrip("/") + "/rest/v1/articles"
+    headers = {
+        "apikey": srv_key,
+        "Authorization": f"Bearer {srv_key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+    }
+    params = {"slug": f"eq.{slug}"}
+    payload = {"category": category}
+    r = requests.patch(url, headers=headers, params=params, data=json.dumps(payload), timeout=20)
+    if r.status_code in (200, 204):
+        print(f"[OK] {slug} → category='{category}'")
+        return True
+    print(f"[ERR] {slug}: {r.status_code} {r.text}")
+    return False
+
+def main():
+    if len(sys.argv) < 3:
+        print("Uso: update_category.py <nuova_category> <slug1> [slug2] ...")
+        sys.exit(2)
+
+    category = sys.argv[1]
+    slugs = sys.argv[2:]
+
+    env = load_env()
+    base = env.get("NEXT_PUBLIC_SUPABASE_URL")
+    srv  = env.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not base or not srv:
+        raise RuntimeError("Chiavi mancanti in .env.local: NEXT_PUBLIC_SUPABASE_URL e/o SUPABASE_SERVICE_ROLE_KEY")
+
+    ok = 0
+    for slug in slugs:
+        ok += 1 if patch_category(base, srv, slug, category) else 0
+
+    print(f"[DONE] Aggiornati {ok}/{len(slugs)} slug.")
+
+if __name__ == "__main__":
+    main()

--- a/progress_log.md
+++ b/progress_log.md
@@ -1,1 +1,7 @@
-﻿
+﻿## 2025-09-25 — Fase: copertine locali per blog (3h)
+- Script Tools/setup_local_covers.py per normalizzare cover_url su asset locali
+- Placeholder locale /public/covers/placeholder.svg
+- Aggiornate pagine blog (lista/dettaglio/categoria) a usare solo next/image con asset locali
+- Rimozione rotte legacy non localizzate /app/blog
+- Verifica end-to-end /it/blog e categorie
+Esito: ✅ ok in dev

--- a/webapp/.env.db
+++ b/webapp/.env.db
@@ -1,6 +1,0 @@
-SUPABASE_DB_URL=postgresql://postgres.twwgfrbcndouazujgcma:L4F1uN9IQ2ssmGEd@aws-1-eu-west-2.pooler.supabase.com:5432/postgres?sslmode=require
-
-
-
-
-

--- a/webapp/app/[locale]/blog/[slug]/page.tsx
+++ b/webapp/app/[locale]/blog/[slug]/page.tsx
@@ -1,92 +1,73 @@
-import { notFound } from "next/navigation";
-import CategoryBadge from "@/components/ui/CategoryBadge";
-import { getSupabasePublicServer } from "@/lib/supabaseServerPublic";
-import { marked } from "marked";
-import { sanitizeHtml } from "@/lib/sanitize";
 import Image from "next/image";
-import CategoryTag from "@/components/ui/CategoryTag";
-import type { Metadata, ResolvingMetadata } from "next";
+import ReactMarkdown from "react-markdown";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { supabase } from "@/lib/supabase";
 
-type Props = { params: { locale: string; slug: string } };
+export const revalidate = 60;
 
-async function fetchPost(slug: string) {
-  const supa = getSupabasePublicServer();
-  const { data } = await supa
-    .from("articles")
-    .select("id,title,excerpt,content,cover_url,slug,published_at")
-    .eq("slug", slug)
-    .single();
-  return data || null;
+function localCover(cover: string | null, slug: string): string {
+  if (cover && cover.startsWith("/")) return cover;
+  return `/covers/${slug}.jpg`;
 }
 
-export async function generateMetadata(
-  { params }: Props,
-  _parent: ResolvingMetadata
-): Promise<Metadata> {
-  const post = await fetchPost(params.slug);
-  if (!post) return {};
-  const title = post.title;
-  const description = post.excerpt ?? "";
-  const base = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
-  const url = `${base}/${params.locale}/blog/${post.slug}`;
-  const images = post.cover_url ? [{ url: post.cover_url }] : undefined;
+async function getSeo(slug: string) {
+  const { data } = await supabase
+    .from("articles")
+    .select("title,summary,cover_url")
+    .eq("slug", slug)
+    .eq("published", true)
+    .maybeSingle();
+  return data ?? null;
+}
+
+export async function generateMetadata({ params }: { params: { slug: string; locale: string } }): Promise<Metadata> {
+  const d = await getSeo(params.slug);
   return {
-    title,
-    description,
-    openGraph: { title, description, url, type: "article", images },
-    alternates: { canonical: url },
+    title: d?.title ?? "Articolo",
+    description: d?.summary ?? undefined,
+    openGraph: d ? { images: [{ url: localCover(d.cover_url ?? null, params.slug) }] } : undefined,
   };
 }
 
-export default async function BlogPostPage({ params }: Props) {
-  const post = await fetchPost(params.slug);
-  if (!post) return notFound();
+async function getArticle(slug: string, locale: string) {
+  const { data, error } = await supabase
+    .from("articles")
+    .select("slug,title,summary,body_md,cover_url,category,published_at,locale")
+    .eq("slug", slug)
+    .eq("locale", locale)
+    .eq("published", true)
+    .maybeSingle();
+  if (error) return null;
+  return data ?? null;
+}
 
-  const html = post.content
-    ? sanitizeHtml(await marked.parse(post.content))
-    : (post.excerpt ? `<p>${sanitizeHtml(post.excerpt)}</p>` : "");
+export default async function BlogDetail({ params }: { params: { locale: string; slug: string } }) {
+  const a = await getArticle(params.slug, params.locale);
+  if (!a) return notFound();
 
-  const dateStr = post.published_at
-    ? new Date(post.published_at).toLocaleDateString(params.locale, {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      })
-    : "";
+  const src = localCover(a.cover_url, a.slug);
 
   return (
-    <article className="mx-auto max-w-3xl px-4 md:px-6 py-8 md:py-12 space-y-6">
-      <header className="space-y-3">
-        <CategoryTag>Blog</CategoryTag>
-        {post?.categories?.length ? (
-  <div className="mb-3 flex gap-2">{/* __PL7_CATEGORIES__ */}
-    {post.categories.map((c:any)=> (
-      <CategoryBadge key={c.id} locale={params.locale} slug={c.slug} label={c.name || c.slug} />
-    ))}
-  </div>
-) : null}
-<h1 className="text-3xl md:text-4xl font-extrabold leading-tight">{post.title}</h1>
-        <p className="text-sm text-gray-500">{dateStr}</p>
-      </header>
+    <main className="mx-auto max-w-3xl p-6">
+      <p className="text-xs opacity-70">{a.category} · {a.locale}</p>
+      <h1 className="text-3xl font-bold mt-1">{a.title}</h1>
 
-      {post.cover_url && (
-        <figure className="w-full">
-          <div className="relative w-full aspect-[16/9] overflow-hidden rounded-xl">
-            <Image
-              src={post.cover_url}
-              alt={post.title ?? ""}
-              fill
-              sizes="(max-width: 768px) 100vw, 768px"
-              className="object-cover"
-              priority={false}
-            />
-          </div>
-        </figure>
-      )}
+      <div className="relative w-full h-64 my-4">
+        <Image
+          src={src}
+          alt={a.title}
+          fill
+          sizes="(min-width:1024px) 768px, 100vw"
+          className="object-cover rounded-2xl"
+        />
+      </div>
 
-      {post.excerpt && <p className="text-lg md:text-xl text-gray-700 leading-relaxed">{post.excerpt}</p>}
+      {a.summary && <p className="italic opacity-80">{a.summary}</p>}
 
-      <div className="prose prose-neutral md:prose-lg max-w-none" dangerouslySetInnerHTML={{ __html: html }} />
-    </article>
+      <article className="prose prose-neutral max-w-none mt-6">
+        <ReactMarkdown>{a.body_md}</ReactMarkdown>
+      </article>
+    </main>
   );
 }

--- a/webapp/app/[locale]/blog/categoria/[slug]/page.tsx
+++ b/webapp/app/[locale]/blog/categoria/[slug]/page.tsx
@@ -1,0 +1,82 @@
+﻿import Link from "next/link";
+import Image from "next/image";
+import type { Metadata } from "next";
+import { supabase } from "@/lib/supabase";
+
+export const revalidate = 60;
+
+type Row = { slug: string; title: string; summary: string | null; cover_url: string | null };
+
+function localCover(cover: string | null, slug: string): string {
+  if (cover && cover.startsWith("/")) return cover;
+  return `/covers/${slug}.jpg`;
+}
+
+async function getData(category: string, locale: string) {
+  const { data, error } = await supabase
+    .from("articles")
+    .select("slug,title,summary,cover_url")
+    .eq("published", true)
+    .eq("category", category)
+    .eq("locale", locale)
+    .order("published_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as Row[];
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: string; slug: string };
+}): Promise<Metadata> {
+  const { locale, slug } = params;
+  const title = locale === "en" ? `Category: ${slug} (en)` : `Categoria: ${slug} (${locale})`;
+  const description = locale === "en" ? `Posts in category "${slug}".` : `Articoli nella categoria "${slug}".`;
+  return { title, description };
+}
+
+export default async function CategoryPage({
+  params,
+}: {
+  params: { locale: string; slug: string };
+}) {
+  const { locale, slug } = params;
+  const items = await getData(slug, locale);
+
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <h1 className="text-3xl font-bold mb-6">
+        {locale === "en" ? "Category" : "Categoria"}: {slug} ({locale})
+      </h1>
+
+      {items.length === 0 && (
+        <p className="opacity-70">
+          {locale === "en" ? "No posts in this category." : "Nessun articolo in questa categoria."}
+        </p>
+      )}
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((a) => {
+          const src = localCover(a.cover_url, a.slug);
+          return (
+            <article key={a.slug} className="rounded-2xl border p-4 hover:shadow-md transition">
+              <div className="relative w-full h-40 mb-3">
+                <Image
+                  src={src}
+                  alt={a.title}
+                  fill
+                  sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
+                  className="object-cover rounded-xl"
+                />
+              </div>
+              <h2 className="text-lg font-semibold mt-1">
+                <Link href={`/${locale}/blog/${a.slug}`} className="hover:underline">{a.title}</Link>
+              </h2>
+              {a.summary && <p className="text-sm mt-2 line-clamp-3">{a.summary}</p>}
+            </article>
+          );
+        })}
+      </div>
+    </main>
+  );
+}

--- a/webapp/app/[locale]/blog/category/[slug]/page.tsx
+++ b/webapp/app/[locale]/blog/category/[slug]/page.tsx
@@ -1,40 +1,83 @@
 import Link from "next/link";
-import { supabaseBrowser } from "@/lib/supabaseBrowser";
+import Image from "next/image";
+import type { Metadata } from "next";
+import { supabase } from "@/lib/supabase";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 60;
 
-export default async function CategoryPage({ params:{ locale, slug } }:{
-  params:{ locale:string; slug:string }
-}) {
-  const sb = supabaseBrowser();
-  // usa una view se ce l'hai; altrimenti adatta con la tua tabella traduzioni
-  const { data, error } = await sb
-    .from("posts_by_category_view")
-    .select("slug, title, summary, cover_url, published_at")
+type Row = { slug: string; title: string; summary: string | null; cover_url: string | null };
+
+function localCover(cover: string | null, slug: string): string {
+  if (cover && cover.startsWith("/")) return cover;
+  return `/covers/${slug}.jpg`;
+}
+
+async function getData(category: string, locale: string) {
+  const { data, error } = await supabase
+    .from("articles")
+    .select("slug,title,summary,cover_url")
+    .eq("published", true)
+    .eq("category", category)
     .eq("locale", locale)
-    .eq("category_slug", slug)
-    .order("published_at", { ascending:false });
+    .order("published_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as Row[];
+}
 
-  if (error) {
-    console.error(error);
-  }
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: string; slug: string };
+}): Promise<Metadata> {
+  const { locale, slug } = params;
+  const title = locale === "en" ? `Category: ${slug} (en)` : `Categoria: ${slug} (${locale})`;
+  const description = locale === "en" ? `Posts in category "${slug}".` : `Articoli nella categoria "${slug}".`;
+  return { title, description };
+}
+
+export default async function CategoryPage({
+  params,
+}: {
+  params: { locale: string; slug: string };
+}) {
+  const { locale, slug } = params;
+  const items = await getData(slug, locale);
 
   return (
-    <main className="mx-auto max-w-5xl px-4 py-8">
-      <h1 className="text-3xl font-bold mb-6">{slug}</h1>
-      <ul className="grid gap-8 md:grid-cols-2">
-        {(data ?? []).map((p:any)=>(
-          <li key={p.slug} className="group">
-            <Link href={`/${locale}/blog/${p.slug}`}>
-              <div className="space-y-2">
-                {p.cover_url && <img src={p.cover_url} className="rounded-xl" alt="" />}
-                <h2 className="text-xl font-semibold group-hover:underline">{p.title}</h2>
-                {p.summary && <p className="text-slate-600">{p.summary}</p>}
+    <main className="mx-auto max-w-5xl p-6">
+      <h1 className="text-3xl font-bold mb-6">
+        {locale === "en" ? "Category" : "Categoria"}: {slug} ({locale})
+      </h1>
+
+      {items.length === 0 && (
+        <p className="opacity-70">
+          {locale === "en" ? "No posts in this category." : "Nessun articolo in questa categoria."}
+        </p>
+      )}
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((a) => {
+          const src = localCover(a.cover_url, a.slug);
+          return (
+            <article key={a.slug} className="rounded-2xl border p-4 hover:shadow-md transition">
+              <div className="relative w-full h-40 mb-3">
+                <Image
+                  src={src}
+                  alt={a.title}
+                  fill
+                  sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
+                  className="object-cover rounded-xl"
+                  onError={(e) => { (e.currentTarget as any).src = "/covers/placeholder.svg"; }}
+                />
               </div>
-            </Link>
-          </li>
-        ))}
-      </ul>
+              <h2 className="text-lg font-semibold mt-1">
+                <Link href={`/${locale}/blog/${a.slug}`} className="hover:underline">{a.title}</Link>
+              </h2>
+              {a.summary && <p className="text-sm mt-2 line-clamp-3">{a.summary}</p>}
+            </article>
+          );
+        })}
+      </div>
     </main>
   );
 }

--- a/webapp/app/[locale]/blog/page.tsx
+++ b/webapp/app/[locale]/blog/page.tsx
@@ -1,115 +1,65 @@
 import Link from "next/link";
-import { notFound } from "next/navigation";
-import { getTranslations } from "next-intl/server";
-import { getSupabasePublicServer } from "@/lib/supabaseServerPublic";
+import Image from "next/image";
+import { supabase } from "@/lib/supabase";
 
-const PAGE_SIZE = 10;
+export const revalidate = 60;
 
-function getPage(searchParams: Record<string, string | string[] | undefined>) {
-  const raw = Array.isArray(searchParams.page)
-    ? searchParams.page[0]
-    : searchParams.page;
-  const n = Number(raw ?? "1");
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 1;
+type Row = {
+  slug: string;
+  title: string;
+  summary: string | null;
+  cover_url: string | null;
+  category: string | null;
+  published_at: string | null;
+  locale: string | null;
+};
+
+function localCover(cover: string | null, slug: string): string {
+  if (cover && cover.startsWith("/")) return cover;
+  return `/covers/${slug}.jpg`;
 }
 
-export const dynamic = "force-dynamic";
-
-export default async function BlogListPage({
-  params,
-  searchParams,
-}: {
-  params: { locale: string };
-  searchParams: Record<string, string | string[] | undefined>;
-}) {
-  const t = await getTranslations("blog");
-  const page = getPage(searchParams);
-  const from = (page - 1) * PAGE_SIZE;
-  const to = from + PAGE_SIZE - 1;
-
-  const supa = getSupabasePublicServer();
-
-  const { data: items, error } = await supa
+export default async function BlogList({ params }: { params: { locale: string } }) {
+  const { data, error } = await supabase
     .from("articles")
-    .select("id,title,excerpt,slug,cover_url,published_at", { count: "exact" })
+    .select("slug,title,summary,cover_url,category,published_at,locale")
+    .eq("published", true)
     .order("published_at", { ascending: false })
-    .range(from, to);
+    .limit(24);
 
-  if (error) {
-    // se c'è un problema DB, meglio un 404 pulito che rompere la pagina
-    notFound();
-  }
-
-  const total = (items as any)?.length ?? 0;
-  const showPrev = page > 1;
-  const showNext = total === PAGE_SIZE; // semplice euristica
+  if (error) throw new Error(error.message);
+  const items = (data ?? []) as Row[];
+  const lang = params.locale;
 
   return (
-    <div className="max-w-3xl mx-auto py-10 space-y-8">
-      <header>
-        <h1 className="text-3xl font-bold">{t("title")}</h1>
-        <p className="text-gray-600">{t("intro")}</p>
-      </header>
+    <main className="mx-auto max-w-5xl p-6">
+      <h1 className="text-3xl font-bold mb-6">Blog</h1>
 
-      {(!items || items.length === 0) && (
-        <p className="text-gray-500">{t("empty")}</p>
-      )}
+      {items.length === 0 && <p className="opacity-70">Ancora nessun articolo pubblicato.</p>}
 
-      <ul className="space-y-6">
-        {items?.map((p) => (
-          <li key={p.id} className="border rounded-lg p-4 flex gap-4">
-            {p.cover_url ? (
-              <img
-                src={p.cover_url}
-                alt={p.title}
-                className="w-28 h-28 object-cover rounded"
-              />
-            ) : (
-              <div className="w-28 h-28 rounded bg-gray-100" />
-            )}
-            <div className="flex-1">
-              <Link
-                href={`/${params.locale}/blog/${p.slug}`}
-                className="text-xl font-semibold hover:underline"
-              >
-                {p.title}
-              </Link>
-              <p className="text-gray-600 mt-1 line-clamp-3">{p.excerpt}</p>
-              <p className="text-xs text-gray-400 mt-2">
-                {p.published_at
-                  ? new Date(p.published_at).toLocaleDateString()
-                  : "—"}
-              </p>
-            </div>
-          </li>
-        ))}
-      </ul>
-
-      <nav className="flex items-center justify-between pt-4">
-        <div>
-          {showPrev && (
-            <Link
-              href={`/${params.locale}/blog?page=${page - 1}`}
-              className="px-3 py-1 border rounded"
-            >
-              ← {t("prev")}
-            </Link>
-          )}
-        </div>
-        <div className="text-sm text-gray-500">
-          {t("page")} {page}
-        </div>
-        <div>
-          {showNext && (
-            <Link
-              href={`/${params.locale}/blog?page=${page + 1}`}
-              className="px-3 py-1 border rounded"
-            >
-              {t("next")} →
-            </Link>
-          )}
-        </div>
-      </nav>
-    </div>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((a) => {
+          const src = localCover(a.cover_url, a.slug);
+          return (
+            <article key={a.slug} className="rounded-2xl border p-4 hover:shadow-md transition">
+              <div className="relative w-full h-40 mb-3">
+                <Image
+                  src={src}
+                  alt={a.title}
+                  fill
+                  sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
+                  className="object-cover rounded-xl"
+                />
+              </div>
+              <div className="text-xs opacity-70">{a.category} · {a.locale}</div>
+              <h2 className="text-lg font-semibold mt-1">
+                <Link href={`/${lang}/blog/${a.slug}`} className="hover:underline">{a.title}</Link>
+              </h2>
+              {a.summary && <p className="text-sm mt-2 line-clamp-3">{a.summary}</p>}
+            </article>
+          );
+        })}
+      </div>
+    </main>
   );
 }

--- a/webapp/app/[locale]/layout.tsx
+++ b/webapp/app/[locale]/layout.tsx
@@ -1,76 +1,18 @@
-// app/[locale]/layout.tsx
-import "../globals.css";
+import Nav from "@/components/Nav";
 
-import type { ReactNode } from "react";
-import { notFound } from "next/navigation";
-import { NextIntlClientProvider } from "next-intl";
-import { setRequestLocale } from "next-intl/server";
-import { locales } from "@/i18n/routing";
-
-import SiteHeader from "@/components/SiteHeader";
-import SiteFooter from "@/components/SiteFooter";
-
-import Analytics from '@/components/Analytics';
-import CookieBanner from '@/components/CookieBanner';
-
-const LOCALES = ['it','en'] as const;
-
-/** Pre-render di /it, /en, /fr, /es, /de */
-export function generateStaticParams() {
-  return locales.map((locale) => ({ locale }));
-}
-
-export default async function LocaleLayout({
+export default function LocaleLayout({
   children,
-  params: { locale },
+  params,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   params: { locale: string };
 }) {
-  // Attiva la locale per next-intl
-  setRequestLocale(locale);
-
-  // 404 se la lingua non è supportata
-  if (!locales.includes(locale as any)) notFound();
-
-  // Carica i messaggi della lingua (con fallback)
-  let messages: Record<string, unknown>;
-  try {
-    messages = (await import(`@/messages/${locale}.json`)).default;
-  } catch {
-    // Fallback di sicurezza: prova l'inglese o fallisci con 404
-    try {
-      messages = (await import(`@/messages/en.json`)).default;
-    } catch {
-      notFound();
-    }
-  }
-
   return (
-    <html lang={locale} className="antialiased">
-      <body className="min-h-screen bg-[#f7f4eb] text-neutral-900 flex flex-col">
-        {/* Header fisso in alto alla colonna */}
-        <SiteHeader />
-
-        {/* Contenuto: container centrale responsivo */}
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <main className="container mx-auto max-w-6xl w-full flex-1 px-4 sm:px-6">
-            {children}
-          </main>
-          <Analytics />
-            <CookieBanner />
-          </NextIntlClientProvider>
-
-        {/* Footer ancorato in fondo grazie a flex-col + flex-1 su main */}
-        <SiteFooter />
+    <html lang={params.locale}>
+      <body className="antialiased">
+        <Nav />
+        {children}
       </body>
     </html>
   );
-}
-
-
-export async function generateMetadata({ params }: any) {
-  const site = (process.env.NEXT_PUBLIC_SITE_URL || '').replace(/\/+$/, '');
-  const alternates: Record<string, string> = Object.fromEntries((LOCALES as readonly string[]).map(l => [l, `${site}/${l}`]));
-  return { alternates: { languages: alternates } } as any;
 }

--- a/webapp/app/[locale]/news/[slug]/page.tsx
+++ b/webapp/app/[locale]/news/[slug]/page.tsx
@@ -1,71 +1,50 @@
-// webapp/app/[locale]/news/[slug]/page.tsx
 import Image from "next/image";
-import EditorialLayout from "@/components/EditorialLayout";
-import ArticleBody from "@/components/ArticleBody";
-import { createClient } from "@/lib/supabaseServerPublic";
+import { notFound } from "next/navigation";
+import { supabase } from "@/lib/supabase";
 
-type Props = {
-  params: { locale: string; slug: string };
-};
+export const revalidate = 60;
 
-export default async function NewsDetail({ params }: Props) {
-  const { locale, slug } = params;
-  const supabase = createClient();
+function localCover(cover: string | null, slug: string): string {
+  if (cover && cover.startsWith("/")) return cover;
+  return `/covers/${slug}.jpg`;
+}
 
+async function getNews(slug: string, locale: string) {
   const { data, error } = await supabase
-    .from("news")
-    .select("id, title, summary, body, cover_url, category, lang, created_at")
+    .from("articles")
+    .select("slug,title,summary,body_md,cover_url,locale,category,published")
     .eq("slug", slug)
+    .eq("locale", locale)
+    .eq("published", true)
     .maybeSingle();
+  if (error) return null;
+  return data ?? null;
+}
 
-  if (!data || error || (data.lang && data.lang !== locale)) {
-    return (
-      <EditorialLayout>
-        <div className="py-16">
-          <h1 className="mb-2 text-2xl font-bold">Articolo non trovato</h1>
-          <p className="text-neutral-600">Controlla lo slug o la lingua.</p>
-        </div>
-      </EditorialLayout>
-    );
-  }
+export default async function NewsDetail({ params }: { params: { locale: string; slug: string } }) {
+  const data = await getNews(params.slug, params.locale);
+  if (!data) return notFound();
 
-  const src = data.cover_url || "https://placehold.co/1200x675/png?text=News";
+  const src = localCover(data.cover_url, data.slug);
 
-  // Se in futuro converti Markdown -> HTML, metti l'HTML in "html" e togli "text"
   return (
-    <EditorialLayout>
-      <article className="py-8 sm:py-10">
-        {data.category ? (
-          <div className="text-[12px] font-bold uppercase tracking-[0.06em] text-[#0f766e]">
-            {data.category}
-          </div>
-        ) : null}
+    <main className="mx-auto max-w-3xl p-6">
+      <p className="text-xs opacity-70">{data.category} · {data.locale}</p>
+      <h1 className="text-3xl font-bold mt-1">{data.title}</h1>
 
-        <h1 className="mt-2 text-3xl font-extrabold leading-tight md:text-4xl">
-          {data.title || "Senza titolo"}
-        </h1>
+      <div className="relative w-full h-64 my-4">
+        <Image
+          src={src}
+          alt={data.title}
+          fill
+          sizes="(min-width:1024px) 768px, 100vw"
+          className="object-cover rounded-2xl"
+          onError={(e) => { (e.currentTarget as any).src = "/covers/placeholder.svg"; }}
+        />
+      </div>
 
-        {data.summary ? (
-          <p className="mt-3 text-[18px] leading-relaxed text-neutral-700">
-            {data.summary}
-          </p>
-        ) : null}
-
-        <div className="relative mt-6 aspect-[16/9] w-full overflow-hidden rounded">
-          <Image
-            src={src}
-            alt={data.title || "News"}
-            fill
-            sizes="(max-width: 1024px) 100vw, 960px"
-            className="object-cover"
-            priority
-          />
-        </div>
-
-        <div className="mt-8">
-          <ArticleBody text={data.body} />
-        </div>
-      </article>
-    </EditorialLayout>
+      {data.summary && <p className="italic opacity-80">{data.summary}</p>}
+      {/* Render del body_md se necessario */}
+    </main>
   );
 }

--- a/webapp/app/[locale]/page.tsx
+++ b/webapp/app/[locale]/page.tsx
@@ -1,82 +1,21 @@
-import EditorialLayout from "@/components/EditorialLayout";
-import ArticleCard from "@/components/ArticleCard";
-import { getTranslations } from "next-intl/server";
-import { createClient } from "@supabase/supabase-js";
+import Link from "next/link";
 
-type NewsRow = {
-  id: string | number;
-  slug: string;
-  title: string | null;
-  summary: string | null;
-  lang: string | null;
-};
-
-type Props = { params: { locale: string } };
-
-export default async function HomePage({ params }: Props) {
-  const t = await getTranslations("home");
-  const locale = params.locale;
-
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-  const supabase = createClient(supabaseUrl, supabaseAnon);
-
-  try {
-    const { data, error } = await supabase
-      .from("news")
-      .select("id, slug, title, summary, lang")
-      .order("id", { ascending: false })
-      .limit(6);
-
-    if (error) {
-      console.error("[HOME] Supabase error:", error);
-      return (
-        <EditorialLayout>
-          <section className="py-8 sm:py-10">
-            <h1 className="mb-6 text-3xl font-extrabold">{t("title")}</h1>
-            <p className="text-red-600">Errore nel caricamento delle news.</p>
-          </section>
-        </EditorialLayout>
-      );
-    }
-
-    const rows: NewsRow[] = (data as any[]) ?? [];
-    const items = rows
-      .filter((n) => !n.lang || n.lang === locale)
-      .map((n) => ({
-        href: `/${locale}/news/${n.slug}`,
-        title: n.title ?? "Senza titolo",
-        summary: n.summary ?? null,
-        // colonne non presenti al momento
-        category: null,
-        coverUrl: null,
-      }));
-
-    return (
-      <EditorialLayout>
-        <section className="py-8 sm:py-10">
-          <h1 className="mb-6 text-3xl font-extrabold">{t("title")}</h1>
-          <p className="mb-8 text-[18px] text-neutral-700">{t("intro")}</p>
-
-          <div className="grid gap-6">
-            {items.length === 0 ? (
-              <p className="text-neutral-600">{t("empty")}</p>
-            ) : (
-              items.map((it) => <ArticleCard key={it.href} {...it} />)
-            )}
-          </div>
-        </section>
-      </EditorialLayout>
-    );
-  } catch (e) {
-    console.error("[HOME] Unexpected error:", e);
-    return (
-      <EditorialLayout>
-        <section className="py-8 sm:py-10">
-          <h1 className="mb-6 text-3xl font-extrabold">{t("title")}</h1>
-          <p className="text-red-600">Errore imprevisto nel caricamento.</p>
-        </section>
-      </EditorialLayout>
-    );
-  }
+export default function LocaleHome({ params }: { params: { locale: string } }) {
+  const lang = params.locale;
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <h1 className="text-3xl font-bold mb-4">
+        {lang === "en" ? "Welcome" : "Benvenuto"}
+      </h1>
+      <p className="opacity-80 mb-6">
+        {lang === "en"
+          ? "Explore our latest articles."
+          : "Scopri i nostri ultimi articoli."}
+      </p>
+      <div className="flex gap-4">
+        <Link className="underline" href={`/${lang}/blog`}>Blog</Link>
+        <Link className="underline" href={`/${lang}/news`}>News</Link>
+      </div>
+    </main>
+  );
 }

--- a/webapp/components/ArticleCard.tsx
+++ b/webapp/components/ArticleCard.tsx
@@ -1,45 +1,37 @@
-// webapp/components/ArticleCard.tsx
-import Image from "next/image";
 import Link from "next/link";
+import Image from "next/image";
 
 type Props = {
   href: string;
   title: string;
   summary?: string | null;
-  category?: string | null;
-  coverUrl?: string | null;
+  slug: string;
+  cover_url?: string | null;
 };
 
-export default function ArticleCard({ href, title, summary, category, coverUrl }: Props) {
-  const src = coverUrl || "https://placehold.co/640x360/png?text=News";
+function localCover(cover: string | null | undefined, slug: string): string {
+  if (cover && cover.startsWith("/")) return cover;
+  return `/covers/${slug}.jpg`;
+}
+
+export default function ArticleCard({ href, title, summary, slug, cover_url }: Props) {
+  const src = localCover(cover_url ?? null, slug);
+
   return (
-    <article className="grid grid-cols-1 gap-4 py-6 md:grid-cols-[280px,1fr] md:gap-6 md:py-8 border-b border-neutral-200">
-      <Link href={href} className="relative block aspect-[16/9] w-full overflow-hidden rounded md:h-[160px]">
+    <article className="rounded-2xl border p-4 hover:shadow-md transition">
+      <div className="relative w-full h-40 mb-3">
         <Image
           src={src}
           alt={title}
           fill
-          sizes="(max-width: 768px) 100vw, 280px"
-          className="object-cover transition-transform duration-300 hover:scale-[1.02]"
+          sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
+          className="object-cover rounded-xl"
         />
-      </Link>
-      <div className="flex flex-col gap-2">
-        {category ? (
-          <div className="text-[11px] font-bold uppercase tracking-[0.05em] text-[#0f766e]">
-            {category}
-          </div>
-        ) : null}
-        <Link href={href} className="group">
-          <h3 className="text-2xl font-extrabold leading-snug group-hover:underline underline-offset-4">
-            {title}
-          </h3>
-        </Link>
-        {summary ? (
-          <p className="text-[17px] leading-relaxed text-neutral-700">
-            {summary}
-          </p>
-        ) : null}
       </div>
+      <h3 className="text-lg font-semibold mt-1">
+        <Link href={href} className="hover:underline">{title}</Link>
+      </h3>
+      {summary && <p className="text-sm mt-2 line-clamp-3">{summary}</p>}
     </article>
   );
 }

--- a/webapp/components/Nav.tsx
+++ b/webapp/components/Nav.tsx
@@ -1,24 +1,24 @@
-'use client';
-import Link from 'next/link';
-import {usePathname} from 'next/navigation';
-import {useTranslations} from 'next-intl';
+"use client";
 
-export default function Nav(){
-  const pathname = usePathname() || '/it';
-  const locale = (pathname.split('/')[1] || 'it');
-  const t = useTranslations('nav');
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 
-  const link = (slug:string) => `/${locale}${slug}`;
+function getLangFromPath(path: string): string {
+  const seg = (path || "/").split("/").filter(Boolean);
+  const lang = seg[0];
+  return lang === "it" || lang === "en" ? lang : "it";
+}
+
+export default function Nav() {
+  const pathname = usePathname() || "/";
+  const lang = getLangFromPath(pathname);
 
   return (
-    <nav style={{display:'flex',gap:'1rem',padding:'1rem',borderBottom:'1px solid #eee'}}>
-      <Link href={link('')}>{t('home')}</Link>
-      <Link href={link('/about')}>{t('about')}</Link>
-      <Link href={link('/news')}>{t('news')}</Link>
-      <Link href={link('/articles')}>{t('articles')}</Link>
-      <Link href={link('/faq')}>{t('faq')}</Link>
-      <Link href={link('/glossary')}>{t('glossary')}</Link>
-      <Link href={link('/contact')}>{t('contact')}</Link>
+    <nav className="p-4 border-b flex gap-4 text-sm">
+      <Link href={`/${lang}`} className="hover:underline">Home</Link>
+      <Link href={`/${lang}/blog`} className="hover:underline">Blog</Link>
+      <Link href={`/${lang}/news`} className="hover:underline">News</Link>
+      <Link href={`/${lang}/contact`} className="hover:underline">Contact</Link>
     </nav>
   );
 }

--- a/webapp/lib/supabase.ts
+++ b/webapp/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -1,0 +1,9 @@
+// webapp/next.config.js
+module.exports = {
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'images.unsplash.com' },
+      { protocol: 'https', hostname: 'res.cloudinary.com' }
+    ],
+  },
+};

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,6 +20,7 @@
         "marked": "^16.3.0",
         "next": "14.2.5",
         "next-intl": "^4.3.6",
+        "next-sitemap": "^4.2.3",
         "postcss": "^8.5.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -87,6 +88,12 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
       "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
@@ -703,7 +710,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -717,7 +723,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -727,7 +732,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2141,7 +2145,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3461,7 +3464,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3478,7 +3480,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3505,7 +3506,6 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3528,7 +3528,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4348,7 +4347,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4403,7 +4401,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4452,7 +4449,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5392,7 +5388,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -5844,7 +5839,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5871,7 +5865,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6048,6 +6041,39 @@
           "optional": true
         }
       }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
+      }
+    },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+      "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+      "license": "MIT"
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
@@ -6416,7 +6442,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6526,7 +6551,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6732,7 +6756,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6788,7 +6811,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7557,7 +7579,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -26,6 +26,7 @@
     "marked": "^16.3.0",
     "next": "14.2.5",
     "next-intl": "^4.3.6",
+    "next-sitemap": "^4.2.3",
     "postcss": "^8.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/webapp/public/covers/placeholder.svg
+++ b/webapp/public/covers/placeholder.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800">
+  <defs>
+    <style>
+      .bg { fill: #f2f2f2; }
+      .rect { fill: #d9d9d9; }
+      .txt { font: 48px sans-serif; fill: #777; }
+    </style>
+  </defs>
+  <rect class="bg" width="100%" height="100%"/>
+  <rect class="rect" x="100" y="120" width="1000" height="560" rx="24"/>
+  <text class="txt" x="50%" y="50%" text-anchor="middle" dominant-baseline="middle">No cover</text>
+</svg>

--- a/worklog.md
+++ b/worklog.md
@@ -115,3 +115,5 @@
 ⏱ 6h
 
 
+2025-09-25 | 3h | Local cover assets + blog pages refactor
+Tasks: tools + pagine Next.js + pulizia rotte legacy + test

--- a/worklog.md
+++ b/worklog.md
@@ -100,3 +100,18 @@
 - link header+footer
 ⏱ 2h
 
+### 📌 2025-09-20 – PL-7 – Blog: categorie + pagina singolo pronta
+- badge categoria
+- pagina categoria
+- SEO base
+⏱ 45m
+
+### 📌 2025-09-21 – PL-6z – Diagnostica DB & decisione cambio istanza
+- Verifiche connessione Supabase (session/transaction pooler, direct)
+- Test DNS/porte, variabili d’ambiente, encoding password
+- Valutazione piani A/B (nuovo progetto Supabase vs Neon+Prisma)
+- Decisione: procedere con nuovo progetto Supabase (piano A)
+
+⏱ 6h
+
+


### PR DESCRIPTION
### Cosa include
- Usa solo asset locali in `/public/covers` (niente host esterni).
- Aggiunto `Tools/setup_local_covers.py` per normalizzare `cover_url`.
- Placeholder locale `public/covers/placeholder.svg`.
- Pagine blog (lista/dettaglio/categoria) aggiornate con `next/image` e helper `localCover`.
- Rimozione pagine legacy non localizzate.

### Verifiche
- Dev build OK (`npm run dev`).
- Nessun `src={a.cover_url}` né `placehold.co` nel codice.
- `cover_url` nel DB punta a `/covers/<slug>.*` o `/covers/placeholder.svg`.

### QA rapido
- `/it/blog` mostra le card con cover locali.
- `/it/blog/categoria/evergreen` popolata.
- Dettagli articoli IT raggiungibili.

### Note
- `.env*` non tracciati.
- Ore registrate: 3h (progress_log.md, worklog.md).
